### PR TITLE
add Tool - Google Colab

### DIFF
--- a/docs/data/tools.yml
+++ b/docs/data/tools.yml
@@ -2157,3 +2157,17 @@
     open-source: True
     destaque: True
     desativado: False
+-
+    id: 157
+    nome: "Google Collaboratory"
+    link: https://colab.research.google.com/
+    github: https://github.com/googlecolab
+    descrição: "Bloco de notas e editor de códigos disponível para uso na web."
+    categoria:
+        - Análise
+        - Visualização
+    plataforma:
+        - Web
+    open-source: False
+    destaque: False
+    desativado: True


### PR DESCRIPTION
**Nome da ferramenta:** Google Collaboratory

**Descrição da ferramenta:** Bloco de notas e editor de códigos disponível para uso na web.

**Motivo para adicionar à base:** É uma ferramenta muito usada para análise de dados e IA e ainda não estava na plataforma.

**Mais informações sobre a ferramenta:** https://colab.research.google.com/